### PR TITLE
Reduce image size, update NodeJS, run as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,29 @@
-#See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
-
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
-WORKDIR /app
-EXPOSE 80
-EXPOSE 443
-VOLUME inbox outbox archive
-RUN apt-get update
-RUN apt-get install -y curl
-RUN apt-get install -y libpng-dev libjpeg-dev curl libxi6 build-essential libgl1-mesa-glx
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
-RUN apt-get install -y nodejs
-
+# Build stage for compiling the application
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
-RUN apt-get update
-RUN apt-get install -y curl
-RUN apt-get install -y libpng-dev libjpeg-dev curl libxi6 build-essential libgl1-mesa-glx
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
-RUN apt-get install -y nodejs
 WORKDIR /src
-COPY ["PDFWebEdit.csproj", "."]
-RUN dotnet restore "./PDFWebEdit.csproj"
-COPY . .
-WORKDIR "/src/."
-RUN dotnet build "PDFWebEdit.csproj" -c Release -o /app/build
 
-FROM build AS publish
+RUN apt-get update && \
+    apt-get install -y curl libpng-dev libjpeg-dev libxi6 build-essential libgl1-mesa-glx && \
+    curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY ["PDFWebEdit.csproj", "./"]
+RUN dotnet restore "PDFWebEdit.csproj"
+
+COPY . .
 RUN dotnet publish "PDFWebEdit.csproj" -c Release -o /app/publish
 
-FROM base AS final
+# Runtime image
+FROM mcr.microsoft.com/dotnet/aspnet:6.0
 WORKDIR /app
-COPY --from=publish /app/publish .
+EXPOSE 8080
+ENV ASPNETCORE_URLS=http://*:8080
+
+COPY --from=build /app/publish .
+
+RUN useradd --create-home app
+
+USER app
+VOLUME inbox outbox archive
 ENTRYPOINT ["dotnet", "PDFWebEdit.dll"]


### PR DESCRIPTION
- Reduce Docker image size  (#13)
  - Original: 830.71 MB
  - This PR: 244.95 MB
- Update NodeJS to v18 LTS
- Run application as non-root user
  - Since the user is not root, the running port number was changed to 8080 instead of 80 (which requires root access).
  - This change requires creating the 4 root volume directories in advance, otherwise, they are created by the docker service as root. Subsequent directories and files are created as the user.
  - Specify `--user $UID:${GROUPS[0]}` in your docker run command to use your current user ids.
  - A cleaner solution would be to update the project to use .NET 8 images.